### PR TITLE
Add rich text paragraph node to example event

### DIFF
--- a/data/events/52d88bad-1808-4f12-979d-6fcfbc47c073.json
+++ b/data/events/52d88bad-1808-4f12-979d-6fcfbc47c073.json
@@ -7,7 +7,16 @@
     }
   ],
   "auto_generate_web_page": true,
-  "description": "Lorem ipsum dolor sit amet consectetur. Elit proin tortor egestas ornare. Non in risus proin in augue justo turpis odio bibendum. Aliquam elementum faucibus sit libero sit auctor nulla dictumst. Cursus tincidunt tempor varius id adipiscing odio sapien suspendisse proin. Nunc nunc libero feugiat enim nibh suspendisse. Id etiam convallis quam non nunc sed velit. Tincidunt a adipiscing netus odio.",
+  "description": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "text": ""
+        }
+      ]
+    }
+  ],
   "citation": null,
   "created_at": "2024-06-06T20:19:25+0000",
   "created_by": "tanyaclement",


### PR DESCRIPTION
# Summary

This PR updates the example event to use an empty Slate paragraph node instead of a plain string, corresponding to the latest data model for events.